### PR TITLE
catch gurobi errors

### DIFF
--- a/rsome/grb_solver.py
+++ b/rsome/grb_solver.py
@@ -71,7 +71,7 @@ def solve(formula, display=True, params={}):
     try:
         solution = Solution(grb.ObjVal, np.array(grb.getAttr('X')),
                             grb.Status, grb.Runtime)
-    except AttributeError:
+    except (AttributeError, gp.GurobiError):
         warnings.warn('Fail to find the optimal solution.')
         solution = None
 


### PR DESCRIPTION
This PR edits the `solve` function in `grb_solver` to catch gurobi errors
When the solution is infeasible the `grb.getAttr('X')` in line 72 returns a `gurobipy.GurobiError`
Before this PR the try-except catches only `AttributeError` and therefore program crash